### PR TITLE
Case insensitive language code validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-trg/language-code-service",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "NPM package to provide an interface for interacting with language codes supported by ISO 639-1 and ISO 639-3.",
   "main": "commonjs/index.js",
   "module": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,8 @@ class LanguageCodeService {
       return null
     }
 
-    let matchedLanguages = this.languages.filter((language) => language.tag == parsedLangTag.primarySubTag)
+    const primarySubTag = parsedLangTag.primarySubTag.toLowerCase()
+    let matchedLanguages = this.languages.filter((language) => language.tag.toLowerCase() === primarySubTag)
 
     return matchedLanguages.length > 0 ? matchedLanguages[0] : null
   }


### PR DESCRIPTION
Since validation of language code only occurs at the primary sub tag, there is no good reason to make this validation case sensitive. It has proven only tedious to users. 